### PR TITLE
Support MSEdge / migrate to event page model

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -1,18 +1,27 @@
-var imageOnClick = (info, tab) => {
-  chrome.storage.local.get('autoSearch', (res) => {
+if (!self.browser && self.chrome) {
+  browser = chrome;
+}
+
+browser.runtime.onInstalled.addListener(() => {
+  browser.contextMenus.create({
+    id: 'search-on-whatanime.ga',
+    title: 'Search on whatanime.ga',
+    contexts: ['image']
+  })
+});
+
+browser.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId !== "search-on-whatanime.ga") {
+    return;
+  }
+
+  browser.storage.local.get('autoSearch', (res) => {
     let searchURL = 'https://whatanime.ga/?auto&url=' + info.srcUrl
     if (res.autoSearch === false) {
       searchURL = 'https://whatanime.ga/?url=' + info.srcUrl
     }
-    chrome.tabs.create({
+    browser.tabs.create({
       url: searchURL
     })
   })
-}
-
-chrome.contextMenus.create({
-  id: 'search-on-whatanime.ga',
-  title: 'Search on whatanime.ga',
-  contexts: ['image'],
-  onclick: imageOnClick
-})
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,10 @@
 {
+    "author": "soruly",
     "background": {
         "scripts": [
             "bg.js"
-        ]
+        ],
+		"persistent": false
     },
     "description": "Use anime screenshots to search where this scene is taken from.",
     "icons": {


### PR DESCRIPTION
Fixes #1:
1. Support MSEdge
   - MSEdge only supports browser.\* rather than chrome.*
   - [MSEdge requires `author` field and `background.persistent` field on manifest.json](https://developer.microsoft.com/en-us/microsoft-edge/platform/documentation/extensions/troubleshooting/) ([See more](https://developer.microsoft.com/en-us/microsoft-edge/platform/documentation/extensions/api-support/supported-manifest-keys/))
2. Migrate to event page model
   - [Event page model is strongly recommended and should be preferred to current background page model](https://developer.chrome.com/extensions/event_pages). (Omitting `background.persistent` field automatically makes background-page model.)
   - Event page requires the use of contextMenus.onClicked instead of onclick: http://stackoverflow.com/a/26246735/2460034
